### PR TITLE
Support for Flutter v3.38.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+# Necessary permissions to create releases and tags
+permissions:
+  contents: write
+
 jobs: 
   build:
     runs-on: windows-latest
@@ -21,15 +25,43 @@ jobs:
         node-version: '18'
         cache: 'npm'
     
+    # 1. Extract version from package.json and save to Env Var
+    - name: Get Version from package.json
+      shell: bash
+      run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
     - name: Install dependencies
       run: npm ci
       
     - name: Build executable
       run: npm run dist
       
-    - name: Upload executable
+    # 2. Rename the output file using the extracted version
+    # Assumes builder outputs: "dist/flutter_installer 1.2.0.exe"
+    # Renames to: "dist/flutter_installer.1.2.0.exe"
+    - name: Rename executable
+      shell: bash
+      run: |
+        mv "dist/flutter_installer $VERSION.exe" "dist/flutter_installer.$VERSION.exe"
+      
+    # Optional: Still upload as artifact if you want to download it from the Actions tab
+    - name: Upload executable artifact
       uses: actions/upload-artifact@v4
       with:
-        name:  windows-executable
-        path: dist\flutter_installer 1.2.0.exe
+        name: flutter-installer-${{ env.VERSION }}
+        path: dist/flutter_installer.${{ env.VERSION }}.exe
         retention-days: 30
+
+    # 3. Create Release and Tag
+    - name: Create Release
+      # Only create release on push to main/master (skip on PRs)
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: v${{ env.VERSION }}
+        name: flutter_installer.${{ env.VERSION }}
+        files: dist/flutter_installer.${{ env.VERSION }}.exe
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: Build Executable
+
+on:
+  push: 
+    branches: [ main, master ]
+  pull_request: 
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs: 
+  build:
+    runs-on: windows-latest
+    
+    steps: 
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+      
+    - name: Build executable
+      run: npm run dist
+      
+    - name: Upload executable
+      uses: actions/upload-artifact@v4
+      with:
+        name:  windows-executable
+        path: dist/*. exe
+        retention-days: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,5 +31,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name:  windows-executable
-        path: dist/*. exe
+        path: dist\flutter_installer 1.2.0.exe
         retention-days: 30

--- a/app/download/index.html
+++ b/app/download/index.html
@@ -33,7 +33,7 @@
                         <p id="cmd-name" style="font-style: italic;">version: </p>
                     </li>
                     <li>
-                        <strong>Open JDK 8</strong> &nbsp; &nbsp;
+                        <strong>Open JDK 25</strong> &nbsp; &nbsp;
                         <div id="jdk-loader" class="loader"></div>
                         <i id="jdk-done" class="material-icons completion-icon">done</i>
                         <p id="jdk-name" style="font-style: italic;">version: </p>

--- a/app/install/index.html
+++ b/app/install/index.html
@@ -32,7 +32,7 @@
                         <i id="cmd-done" class="material-icons completion-icon">done</i>
                     </li>
                     <li>
-                        <strong>Open JDK 8</strong> &nbsp; &nbsp;
+                        <strong>Open JDK 25</strong> &nbsp; &nbsp;
                         <div id="jdk-loader" class="loader"></div>
                         <i id="jdk-done" class="material-icons completion-icon">done</i>
                     </li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flutter_installer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An installation toolkit for the flutter framework",
   "main": "main.js",
   "scripts": {

--- a/urls.json
+++ b/urls.json
@@ -1,4 +1,4 @@
 {
-    "command-line-tools": "https://dl.google.com/android/repository/commandlinetools-win-6200805_latest.zip",
-    "jdk": "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u252-b09.1/OpenJDK8U-jdk_x86-32_windows_hotspot_8u252b09.zip"
+    "command-line-tools": "https://dl.google.com/android/repository/commandlinetools-win-13114758_latest.zip",
+    "jdk": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.1%2B8/OpenJDK25U-jdk_x64_windows_hotspot_25.0.1_8.zip"
 }


### PR DESCRIPTION
This pull request updates the project to use OpenJDK 25 instead of OpenJDK 8, from Android Command Line Tools `6200805` to `13114758` and introduces a GitHub Actions workflow for building and uploading a Windows executable. It also bumps the version to 1.2.0 and updates download URLs for dependencies.

**Dependency and Version Updates:**

* Changed all references from `Open JDK 8` to `Open JDK 25` in the installer UI (`app/download/index.html`, `app/install/index.html`). [[1]](diffhunk://#diff-76286d5dc565495336906db9078da71729c21b116734f62fa34d55af4c28793aL36-R36) [[2]](diffhunk://#diff-690a9a2793211f2a5074d43d335f9cc492729fdb5397c501eb085ccb7140444aL35-R35)
* Updated the JDK download URL in `urls.json` to point to OpenJDK 25, and updated the command-line tools URL as well.
* Bumped the project version from 1.1.0 to 1.2.0 in `package.json`.

**CI/CD Improvements:**

* Added a new GitHub Actions workflow (`.github/workflows/main.yml`) to build the Windows executable on pushes and pull requests, and to upload the built artifact.